### PR TITLE
Spatially variable runoff cap set by namelist

### DIFF
--- a/source/cpl_arrays.F90
+++ b/source/cpl_arrays.F90
@@ -48,7 +48,7 @@ module cpl_arrays
       !----------------------------------------------------------------
   
   ! Fields received
-  real(kind=dbl_kind),dimension(:,:),allocatable :: &
+  real(kind=dbl_kind), dimension(:,:), allocatable :: &
 !!!!      isst, albvdr, albidr, albvdf, albidf
      isst
   

--- a/source/cpl_interfaces.F90
+++ b/source/cpl_interfaces.F90
@@ -133,10 +133,10 @@ contains
   call recv_grid_from_ice()
   if (trim(dataset) == 'jra55') then
     call remap_runoff_new(remap_runoff, 'rmp_jrar_to_cict_CONSERV.nc', &
-                          ice_lats, ice_lons, ice_mask, max_runoff=runoff_cap)
+                          ice_lats, ice_lons, ice_mask, max_runoff=global_runoff_cap)
   else
     call remap_runoff_new(remap_runoff, 'rmp_corr_to_cict_CONSERV.nc', &
-                          ice_lats, ice_lons, ice_mask, max_runoff=runoff_cap)
+                          ice_lats, ice_lons, ice_mask, max_runoff=global_runoff_cap)
   endif
 
   ! Compare the total number of processes and the number of processes

--- a/source/cpl_interfaces.F90
+++ b/source/cpl_interfaces.F90
@@ -133,10 +133,18 @@ contains
   call recv_grid_from_ice()
   if (trim(dataset) == 'jra55') then
     call remap_runoff_new(remap_runoff, 'rmp_jrar_to_cict_CONSERV.nc', &
-                          ice_lats, ice_lons, ice_mask, max_runoff=global_runoff_cap)
+                          ice_lats, ice_lons, ice_mask, &
+                          global_runoff_cap, &
+                          num_runoff_caps, runoff_caps, &
+                          runoff_caps_is, runoff_caps_ie, &
+                          runoff_caps_js, runoff_caps_je)
   else
     call remap_runoff_new(remap_runoff, 'rmp_corr_to_cict_CONSERV.nc', &
-                          ice_lats, ice_lons, ice_mask, max_runoff=global_runoff_cap)
+                          ice_lats, ice_lons, ice_mask, &
+                          global_runoff_cap, &
+                          num_runoff_caps, runoff_caps, &
+                          runoff_caps_is, runoff_caps_ie, &
+                          runoff_caps_js, runoff_caps_je)
   endif
 
   ! Compare the total number of processes and the number of processes

--- a/source/cpl_interfaces.F90
+++ b/source/cpl_interfaces.F90
@@ -36,9 +36,9 @@ integer(kind=int_kind) :: il_commice, my_commice_task
 integer(kind=int_kind) :: il_flag        ! Flag for grid writing
 integer(kind=int_kind) :: il_status, il_fileid, il_varid 
 integer(kind=int_kind), dimension(2) :: icnt   !,ist ==> what is it?
-real(kind=dbl_kind),dimension(nx_global,ny_global) :: dla_lon, dla_lat, dla_srf
-integer(kind=int_kind),dimension(nx_global,ny_global) :: ila_msk 
-real(kind=dbl_kind),dimension(nx_global,ny_global,4) :: dla_lonb, dla_latb
+real(kind=dbl_kind), dimension(nx_global,ny_global) :: dla_lon, dla_lat, dla_srf
+integer(kind=int_kind), dimension(nx_global,ny_global) :: ila_msk 
+real(kind=dbl_kind), dimension(nx_global,ny_global,4) :: dla_lonb, dla_latb
 
 integer(kind=int_kind) :: nx_global_ice, ny_global_ice
 real(kind=dbl_kind), dimension(:, :), allocatable :: ice_lats, ice_lons

--- a/source/cpl_interfaces.F90
+++ b/source/cpl_interfaces.F90
@@ -134,14 +134,12 @@ contains
   if (trim(dataset) == 'jra55') then
     call remap_runoff_new(remap_runoff, 'rmp_jrar_to_cict_CONSERV.nc', &
                           ice_lats, ice_lons, ice_mask, &
-                          global_runoff_cap, &
                           num_runoff_caps, runoff_caps, &
                           runoff_caps_is, runoff_caps_ie, &
                           runoff_caps_js, runoff_caps_je)
   else
     call remap_runoff_new(remap_runoff, 'rmp_corr_to_cict_CONSERV.nc', &
                           ice_lats, ice_lons, ice_mask, &
-                          global_runoff_cap, &
                           num_runoff_caps, runoff_caps, &
                           runoff_caps_is, runoff_caps_ie, &
                           runoff_caps_js, runoff_caps_je)

--- a/source/cpl_parameters.F90
+++ b/source/cpl_parameters.F90
@@ -51,9 +51,11 @@ logical :: debug_output = .false.
 ! The unit of time is seconds. By default fields are dumped every timestep.
 integer(kind=int_kind) :: chk_fields_period = 1
 
-! conservatively spread runoff exceeding global_runoff_cap; set to global_runoff_cap=0.0 to have no global limit to runoff
-integer, parameter :: max_caps = 4 ! maximum number of runoff cap regions in addition to global (increase if want more; also make the arrays below match)
-integer :: num_runoff_caps = 1 ! number of runoff cap regions actually used; anything more than max_caps is ignored
+! Conservatively redistribute runoff exceeding runoff_cap in specified regions.
+! Regions specify grid points that will be checked for whether they exceed the cap;
+! excess runoff from those grid points may be redistributed outside the specified region.
+integer, parameter :: max_caps = 4 ! maximum number of runoff cap regions (increase if want more; also make the default arrays below match)
+integer :: num_runoff_caps = 1 ! number of runoff cap regions to actually use
 real(kind=dbl_kind), dimension(max_caps) :: runoff_caps = (/ 0.03, 0.0, 0.0, 0.0 /) ! kg/m^2/s  runoff cap applied in each region (0.0 = no cap)
 ! runoff cap is applied to all points between or including these index limits
 integer, dimension(max_caps) :: runoff_caps_is = (/ 0, 0, 0, 0 /) ! starting i index for each runoff region (count from 1)

--- a/source/cpl_parameters.F90
+++ b/source/cpl_parameters.F90
@@ -50,8 +50,16 @@ logical :: debug_output = .false.
 ! How often to dump the coupling fields if any of the chk_*_fields options are .true.
 ! The unit of time is seconds. By default fields are dumped every timestep.
 integer(kind=int_kind) :: chk_fields_period = 1
-real(kind=dbl_kind) :: runoff_cap = 0.03  ! kg/m^2/s
-! conservatively spread runoff exceeding runoff_cap; set to runoff_cap=0.0 to have no limit to runoff
+
+real(kind=dbl_kind) :: global_runoff_cap = 0.03  ! kg/m^2/s
+! conservatively spread runoff exceeding global_runoff_cap; set to global_runoff_cap=0.0 to have no global limit to runoff
+integer, parameter :: max_caps = 4 ! maximum number of runoff cap regions in addition to global (increase if want more)
+integer :: num_runoff_caps = 0 ! number of runoff cap regions actually used, in addition to global; anything more than max_caps is ignored
+real(kind=dbl_kind),dimension(max_caps) :: runoff_caps = (/ 0.0, 0.0, 0.0, 0.0 /) ! kg/m^2/s  runoff cap applied in each region (0.0 = no cap)
+integer,dimension(max_caps) :: runoff_caps_is = (/ 0, 0, 0, 0 /) ! starting i index for each runoff region
+integer,dimension(max_caps) :: runoff_caps_ie = (/ 0, 0, 0, 0 /) ! ending i index for each runoff region
+integer,dimension(max_caps) :: runoff_caps_js = (/ 0, 0, 0, 0 /) ! starting j index for each runoff region
+integer,dimension(max_caps) :: runoff_caps_je = (/ 0, 0, 0, 0 /) ! ending j index for each runoff region
 
 namelist/coupling/ &
    init_date, &
@@ -67,7 +75,13 @@ namelist/coupling/ &
    chk_a2i_fields, &   
    chk_i2a_fields, &
    chk_fields_period, &
-   runoff_cap, &
+   global_runoff_cap, &
+   num_runoff_caps, &
+   runoff_caps, &
+   runoff_caps_is, &
+   runoff_caps_ie, &
+   runoff_caps_js, &
+   runoff_caps_je, &
    debug_output
 
 !====================================================================================

--- a/source/cpl_parameters.F90
+++ b/source/cpl_parameters.F90
@@ -53,13 +53,13 @@ integer(kind=int_kind) :: chk_fields_period = 1
 
 real(kind=dbl_kind) :: global_runoff_cap = 0.03  ! kg/m^2/s
 ! conservatively spread runoff exceeding global_runoff_cap; set to global_runoff_cap=0.0 to have no global limit to runoff
-integer, parameter :: max_caps = 4 ! maximum number of runoff cap regions in addition to global (increase if want more)
+integer, parameter :: max_caps = 4 ! maximum number of runoff cap regions in addition to global (increase if want more; also make the arrays below match)
 integer :: num_runoff_caps = 0 ! number of runoff cap regions actually used, in addition to global; anything more than max_caps is ignored
 real(kind=dbl_kind), dimension(max_caps) :: runoff_caps = (/ 0.0, 0.0, 0.0, 0.0 /) ! kg/m^2/s  runoff cap applied in each region (0.0 = no cap)
-(max_caps) :: runoff_caps_is = (/ 0, 0, 0, 0 /) ! starting i index for each runoff region
-integer, dimension(max_caps) :: runoff_caps_ie = (/ 0, 0, 0, 0 /) ! ending i index for each runoff region
+integer, dimension(max_caps) :: runoff_caps_is = (/ 0, 0, 0, 0 /) ! starting i index for each runoff region
+integer, dimension(max_caps) :: runoff_caps_ie = (/ -1, -1, -1, -1 /) ! ending i index for each runoff region
 integer, dimension(max_caps) :: runoff_caps_js = (/ 0, 0, 0, 0 /) ! starting j index for each runoff region
-integer, dimension(max_caps) :: runoff_caps_je = (/ 0, 0, 0, 0 /) ! ending j index for each runoff region
+integer, dimension(max_caps) :: runoff_caps_je = (/ -1, -1, -1, -1 /) ! ending j index for each runoff region
 
 namelist/coupling/ &
    init_date, &

--- a/source/cpl_parameters.F90
+++ b/source/cpl_parameters.F90
@@ -51,15 +51,15 @@ logical :: debug_output = .false.
 ! The unit of time is seconds. By default fields are dumped every timestep.
 integer(kind=int_kind) :: chk_fields_period = 1
 
-real(kind=dbl_kind) :: global_runoff_cap = 0.03  ! kg/m^2/s
 ! conservatively spread runoff exceeding global_runoff_cap; set to global_runoff_cap=0.0 to have no global limit to runoff
 integer, parameter :: max_caps = 4 ! maximum number of runoff cap regions in addition to global (increase if want more; also make the arrays below match)
-integer :: num_runoff_caps = 0 ! number of runoff cap regions actually used, in addition to global; anything more than max_caps is ignored
-real(kind=dbl_kind), dimension(max_caps) :: runoff_caps = (/ 0.0, 0.0, 0.0, 0.0 /) ! kg/m^2/s  runoff cap applied in each region (0.0 = no cap)
-integer, dimension(max_caps) :: runoff_caps_is = (/ 0, 0, 0, 0 /) ! starting i index for each runoff region
-integer, dimension(max_caps) :: runoff_caps_ie = (/ -1, -1, -1, -1 /) ! ending i index for each runoff region
-integer, dimension(max_caps) :: runoff_caps_js = (/ 0, 0, 0, 0 /) ! starting j index for each runoff region
-integer, dimension(max_caps) :: runoff_caps_je = (/ -1, -1, -1, -1 /) ! ending j index for each runoff region
+integer :: num_runoff_caps = 1 ! number of runoff cap regions actually used; anything more than max_caps is ignored
+real(kind=dbl_kind), dimension(max_caps) :: runoff_caps = (/ 0.03, 0.0, 0.0, 0.0 /) ! kg/m^2/s  runoff cap applied in each region (0.0 = no cap)
+! runoff cap is applied to all points between or including these index limits
+integer, dimension(max_caps) :: runoff_caps_is = (/ 0, 0, 0, 0 /) ! starting i index for each runoff region (count from 1)
+integer, dimension(max_caps) :: runoff_caps_ie = (/ 1000000, -1, -1, -1 /) ! ending i index for each runoff region (count from 1)
+integer, dimension(max_caps) :: runoff_caps_js = (/ 0, 0, 0, 0 /) ! starting j index for each runoff region (count from 1)
+integer, dimension(max_caps) :: runoff_caps_je = (/ 1000000, -1, -1, -1 /) ! ending j index for each runoff region (count from 1)
 
 namelist/coupling/ &
    init_date, &
@@ -75,7 +75,6 @@ namelist/coupling/ &
    chk_a2i_fields, &   
    chk_i2a_fields, &
    chk_fields_period, &
-   global_runoff_cap, &
    num_runoff_caps, &
    runoff_caps, &
    runoff_caps_is, &

--- a/source/cpl_parameters.F90
+++ b/source/cpl_parameters.F90
@@ -55,11 +55,11 @@ real(kind=dbl_kind) :: global_runoff_cap = 0.03  ! kg/m^2/s
 ! conservatively spread runoff exceeding global_runoff_cap; set to global_runoff_cap=0.0 to have no global limit to runoff
 integer, parameter :: max_caps = 4 ! maximum number of runoff cap regions in addition to global (increase if want more)
 integer :: num_runoff_caps = 0 ! number of runoff cap regions actually used, in addition to global; anything more than max_caps is ignored
-real(kind=dbl_kind),dimension(max_caps) :: runoff_caps = (/ 0.0, 0.0, 0.0, 0.0 /) ! kg/m^2/s  runoff cap applied in each region (0.0 = no cap)
-integer,dimension(max_caps) :: runoff_caps_is = (/ 0, 0, 0, 0 /) ! starting i index for each runoff region
-integer,dimension(max_caps) :: runoff_caps_ie = (/ 0, 0, 0, 0 /) ! ending i index for each runoff region
-integer,dimension(max_caps) :: runoff_caps_js = (/ 0, 0, 0, 0 /) ! starting j index for each runoff region
-integer,dimension(max_caps) :: runoff_caps_je = (/ 0, 0, 0, 0 /) ! ending j index for each runoff region
+real(kind=dbl_kind), dimension(max_caps) :: runoff_caps = (/ 0.0, 0.0, 0.0, 0.0 /) ! kg/m^2/s  runoff cap applied in each region (0.0 = no cap)
+(max_caps) :: runoff_caps_is = (/ 0, 0, 0, 0 /) ! starting i index for each runoff region
+integer, dimension(max_caps) :: runoff_caps_ie = (/ 0, 0, 0, 0 /) ! ending i index for each runoff region
+integer, dimension(max_caps) :: runoff_caps_js = (/ 0, 0, 0, 0 /) ! starting j index for each runoff region
+integer, dimension(max_caps) :: runoff_caps_je = (/ 0, 0, 0, 0 /) ! ending j index for each runoff region
 
 namelist/coupling/ &
    init_date, &

--- a/source/kdrunoff_mod.F90
+++ b/source/kdrunoff_mod.F90
@@ -99,9 +99,9 @@ contains
     real, dimension(:, :), intent(inout) :: runoff
     real, dimension(:, :), intent(in) :: areas
 
-    integer :: n, i, j, nni, nnj, nn, nn_accum
-    real :: val, val_per_nbr, area_ratio
-    real :: redist, redist_mass, avail_mass
+    integer :: n, i, j, nni, nnj, nn
+    real :: val
+    real :: redist, redist_mass
     type(kdtree2_result), allocatable :: results(:)
 
     if (this%num_ocean_points == 0) then
@@ -132,52 +132,6 @@ contains
     
     call kdrunoff_cap(this, runoff, areas)
 
-    ! ! Now apply a limit to runoff. Runoff is evenly distributed
-    ! ! to a number of neighbours.
-    ! if (this%max_runoff > 0.0) then
-    !   do n=1, size(this%ocean_points, 2)
-    !     i = this%ocean_indices(1, n)
-    !     j = this%ocean_indices(2, n)
-    !     redist = runoff(i, j) - this%max_runoff
-    ! 
-    !     if (redist > 0.0) then
-    !       ! Remove 'redist' to bring down to max_runoff
-    !       runoff(i, j) = runoff(i, j) - redist
-    !       redist_mass = redist * areas(i, j)
-    ! 
-    !       ! Try to redistribute all in several passes because we don't know how
-    !       ! many nearest neighbours are going to be needed.
-    !       nn_accum = 1
-    !       do while (redist_mass > 0.0)
-    !         ! Guess how many nearest neighbours are needed
-    !         ! to redistribute 'redist'. This is big to begin with and grows
-    !         ! linearly.
-    !         nn = (ceiling(redist / this%max_runoff) * 100) + nn_accum
-    !         if (nn > size(this%ocean_points) / 10.0) then
-    !             stop 'Error in kdrunoff_remap: runoff too large to redistribute.'
-    !         endif
-    !         allocate(results(nn))
-    !         call kdtree2_n_nearest(tp=this%tree, qv=this%ocean_points(:, n), &
-    !                                nn=nn, results=results)
-    !         do nn=nn_accum, size(results)
-    !           nni = this%ocean_indices(1, results(nn)%idx)
-    !           nnj = this%ocean_indices(2, results(nn)%idx)
-    !           ! How much of redist can this neighbour accommodate?
-    !           avail_mass = (this%max_runoff - runoff(nni, nnj)) * areas(nni, nnj)
-    !           if (avail_mass > 0.0) then
-    !             avail_mass = min(avail_mass, redist_mass)
-    !             runoff(nni, nnj) = runoff(nni, nnj) + &
-    !                               (avail_mass / areas(nni, nnj))
-    !             redist_mass = redist_mass - avail_mass
-    !           endif
-    !         enddo
-    !         nn_accum = size(results)
-    !         deallocate(results)
-    !       enddo
-    !     endif
-    !   enddo
-    ! endif
-
   end subroutine kdrunoff_remap
   
   subroutine kdrunoff_cap(this, runoff, areas)
@@ -186,35 +140,13 @@ contains
     real, dimension(:, :), intent(in) :: areas
 
     integer :: n, i, j, nni, nnj, nn, nn_accum
-    real :: val, val_per_nbr, area_ratio
+    real :: val
     real :: redist, redist_mass, avail_mass
     type(kdtree2_result), allocatable :: results(:)
 
     if (this%num_ocean_points == 0) then
       return
     endif
-
-    ! allocate(results(1))
-    ! 
-    ! ! Move any runoff that occurs on land nearest ocean point
-    ! do n=1, size(this%land_points, 2)
-    !   i = this%land_indices(1, n)
-    !   j = this%land_indices(2, n)
-    !   val = runoff(i, j)
-    !   if (val > 0.0) then
-    !     call kdtree2_n_nearest(tp=this%tree, qv=this%land_points(:, n), &
-    !                            nn=1, results=results)
-    !     ! Remove runoff from land
-    !     runoff(i, j) = runoff(i, j) - val
-    !     nni = this%ocean_indices(1, results(1)%idx)
-    !     nnj = this%ocean_indices(2, results(1)%idx)
-    !     ! Add runoff to ocean point
-    !     runoff(nni, nnj) = runoff(nni, nnj) + &
-    !                        ((val * areas(i, j)) / areas(nni, nnj))
-    !   endif
-    ! enddo
-    ! 
-    ! deallocate(results)
 
     ! Now apply a limit to runoff. Runoff is evenly distributed
     ! to a number of neighbours.

--- a/source/kdrunoff_mod.F90
+++ b/source/kdrunoff_mod.F90
@@ -19,6 +19,12 @@ module kdrunoff_mod
     ! Maximum runoff (kg/m^2/s) desired. Beyond this and
     ! runoff is redistributed.
     real :: max_runoff
+    ! integer :: num_runoff_caps = 0
+    ! real, dimension(:) :: runoff_caps
+    ! integer, dimension(:) :: runoff_caps_is
+    ! integer, dimension(:) :: runoff_caps_ie
+    ! integer, dimension(:) :: runoff_caps_js
+    ! integer, dimension(:) :: runoff_caps_je
     integer :: num_ocean_points
   end type kdrunoff_class
 
@@ -31,21 +37,30 @@ contains
 
   subroutine kdrunoff_new(this, land_sea_mask, x_t, y_t, &
                           num_land_pts, num_ocean_pts, &
-                          max_runoff)
+                          max_runoff, num_runoff_caps, runoff_caps, &
+                          runoff_caps_is, runoff_caps_ie, &
+                          runoff_caps_js, runoff_caps_je)
     type(kdrunoff_class), intent(inout) :: this
     real, dimension(:, :), intent(in) :: land_sea_mask
     real, dimension(:, :), intent(in) :: x_t, y_t
     integer, intent(out) :: num_land_pts, num_ocean_pts
-    real, optional, intent(in) :: max_runoff
+    real, intent(in) :: max_runoff
+    integer, intent(in) :: num_runoff_caps
+    real, dimension(:), intent(in) :: runoff_caps
+    integer, dimension(:), intent(in) :: runoff_caps_is
+    integer, dimension(:), intent(in) :: runoff_caps_ie
+    integer, dimension(:), intent(in) :: runoff_caps_js
+    integer, dimension(:), intent(in) :: runoff_caps_je
 
     integer :: nx, ny, i, j, n_ocn, n_land
 
-    if (present(max_runoff)) then
-      this%max_runoff = max_runoff
-    else
-      ! No limit to runoff.
-      this%max_runoff = 0.0
-    endif
+    ! if (present(max_runoff)) then
+    !   this%max_runoff = max_runoff
+    ! else
+    !   ! No limit to runoff.
+    !   this%max_runoff = 0.0
+    ! endif
+    this%max_runoff = max_runoff
 
     ! Total number of ocean points.
     this%num_ocean_points = sum(land_sea_mask)

--- a/source/kdrunoff_mod.F90
+++ b/source/kdrunoff_mod.F90
@@ -147,7 +147,8 @@ contains
 
     deallocate(results)
     
-    do n=1,this%num_runoff_caps
+    ! counting down is more efficient if more relaxed global cap is first in array
+    do n=this%num_runoff_caps, 1, -1
       call kdrunoff_cap(this, runoff, areas, this%runoff_caps(n), &
                   this%runoff_caps_is(n), this%runoff_caps_ie(n), &
                   this%runoff_caps_js(n), this%runoff_caps_je(n))

--- a/source/matm.F90
+++ b/source/matm.F90
@@ -100,6 +100,7 @@ PROGRAM datm
   read (99, coupling)
   close(unit=99)
   write(*, coupling)
+  num_runoff_caps = max(0, min(num_runoff_caps, max_caps))
 
   call prism_init
 

--- a/source/remap_runoff_mod.F90
+++ b/source/remap_runoff_mod.F90
@@ -37,12 +37,21 @@ module remap_runoff_mod
 
 contains
 
-  subroutine remap_runoff_new(this, weights, lats, lons, mask, max_runoff)
+  subroutine remap_runoff_new(this, weights, lats, lons, mask, max_runoff, &
+      num_runoff_caps, runoff_caps, &
+      runoff_caps_is, runoff_caps_ie, &
+      runoff_caps_js, runoff_caps_je)
     type(remap_runoff_class), intent(inout) :: this
 
     character(len=*), intent(in) :: weights
     real, dimension(:, :), intent(in) :: lats, lons, mask
     real, optional, intent(in) :: max_runoff
+    integer, optional, intent(in) :: num_runoff_caps
+    real, dimension(:), intent(in) :: runoff_caps
+    integer, dimension(:), intent(in) :: runoff_caps_is
+    integer, dimension(:), intent(in) :: runoff_caps_ie
+    integer, dimension(:), intent(in) :: runoff_caps_js
+    integer, dimension(:), intent(in) :: runoff_caps_je
 
     integer :: ncid
     integer :: n_s, n_a, n_b
@@ -62,13 +71,19 @@ contains
     this%n_a = n_a
     this%n_b = n_b
 
-    if (present(max_runoff)) then
-      call kdrunoff_new(this%kdrunoff, mask, lons, lats, &
-                        this%num_land_pts, this%num_ocean_pts, max_runoff)
-    else
-      call kdrunoff_new(this%kdrunoff, mask, lons, lats, &
-                        this%num_land_pts, this%num_ocean_pts)
-    endif
+    ! if (present(max_runoff)) then
+    !   call kdrunoff_new(this%kdrunoff, mask, lons, lats, &
+    !                     this%num_land_pts, this%num_ocean_pts, max_runoff)
+    ! else
+    !   call kdrunoff_new(this%kdrunoff, mask, lons, lats, &
+    !                     this%num_land_pts, this%num_ocean_pts)
+    ! endif
+    
+    call kdrunoff_new(this%kdrunoff, mask, lons, lats, &
+                      this%num_land_pts, this%num_ocean_pts, &
+                      max_runoff, num_runoff_caps, runoff_caps, &
+                      runoff_caps_is, runoff_caps_ie, &
+                      runoff_caps_js, runoff_caps_je)
 
   end subroutine remap_runoff_new
 

--- a/source/remap_runoff_mod.F90
+++ b/source/remap_runoff_mod.F90
@@ -37,7 +37,7 @@ module remap_runoff_mod
 
 contains
 
-  subroutine remap_runoff_new(this, weights, lats, lons, mask, max_runoff, &
+  subroutine remap_runoff_new(this, weights, lats, lons, mask, &
       num_runoff_caps, runoff_caps, &
       runoff_caps_is, runoff_caps_ie, &
       runoff_caps_js, runoff_caps_je)
@@ -45,8 +45,7 @@ contains
 
     character(len=*), intent(in) :: weights
     real, dimension(:, :), intent(in) :: lats, lons, mask
-    real, optional, intent(in) :: max_runoff
-    integer, optional, intent(in) :: num_runoff_caps
+    integer, intent(in) :: num_runoff_caps
     real, dimension(:), intent(in) :: runoff_caps
     integer, dimension(:), intent(in) :: runoff_caps_is
     integer, dimension(:), intent(in) :: runoff_caps_ie
@@ -73,7 +72,7 @@ contains
     
     call kdrunoff_new(this%kdrunoff, mask, lons, lats, &
                       this%num_land_pts, this%num_ocean_pts, &
-                      max_runoff, num_runoff_caps, runoff_caps, &
+                      num_runoff_caps, runoff_caps, &
                       runoff_caps_is, runoff_caps_ie, &
                       runoff_caps_js, runoff_caps_je)
 

--- a/source/remap_runoff_mod.F90
+++ b/source/remap_runoff_mod.F90
@@ -70,14 +70,6 @@ contains
     this%n_s = n_s
     this%n_a = n_a
     this%n_b = n_b
-
-    ! if (present(max_runoff)) then
-    !   call kdrunoff_new(this%kdrunoff, mask, lons, lats, &
-    !                     this%num_land_pts, this%num_ocean_pts, max_runoff)
-    ! else
-    !   call kdrunoff_new(this%kdrunoff, mask, lons, lats, &
-    !                     this%num_land_pts, this%num_ocean_pts)
-    ! endif
     
     call kdrunoff_new(this%kdrunoff, mask, lons, lats, &
                       this%num_land_pts, this%num_ocean_pts, &


### PR DESCRIPTION
These changes allow us to set different runoff caps in different places in order to selectively control river spreading and avoid negative salinity problems.

I've tested it with a global cap of 0.03 kg/m^2/s together with a more restrictive 0.003 kg/m^2/s cap in Siberian rivers (Ob and Yenesei) to get extra spreading there - see `runoff` field in `/g/data3/hh5/tmp/cosima/access-om2-01/01deg_jra55v13_ryf8485_spinup3/output009/ocean/ocean_month.nc`. 
Parameters were set in this namelist: `/g/data3/hh5/tmp/cosima/access-om2-01/01deg_jra55v13_ryf8485_spinup3/output009/atmosphere/input_atm.nml`.

It is working well so far and has allowed the integration to proceed further without negative salinity crashes. 

Quite a lot of code changes here, so I would appreciate an expert looking over it.