### PR TITLE
Load common modules via environs.access-om2.nci

### DIFF
--- a/build/environs.nci
+++ b/build/environs.nci
@@ -1,6 +1,12 @@
 source /etc/profile.d/nf_csh_modules
-module purge
-module load intel-fc/17.0.1.132
-module load intel-cc/17.0.1.132
-module load netcdf/4.4.1.1
-module load openmpi/1.10.2
+if ( -f ../../../modules.nci ) then
+    echo "Loading common modules via modules.nci"
+    source ../../../modules.nci
+else
+    echo "WARNING: modules.nci not found. Module versions might differ between model components."
+    module purge
+    module load intel-fc/17.0.1.132
+    module load intel-cc/17.0.1.132
+    module load netcdf/4.4.1.1
+    module load openmpi/1.10.2
+endif

--- a/build/environs.nci
+++ b/build/environs.nci
@@ -1,9 +1,9 @@
 source /etc/profile.d/nf_csh_modules
-if ( -f ../../modules.nci ) then
-    echo "Loading common modules via modules.nci"
-    source ../../modules.nci
+if ( -f ../../environs.access-om2.nci ) then
+    echo "Loading common modules via environs.access-om2.nci"
+    source ../../environs.access-om2.nci
 else
-    echo "WARNING: modules.nci not found. Module versions might differ between model components."
+    echo "WARNING: environs.access-om2.nci not found. Module versions might differ between model components."
     module purge
     module load intel-fc/17.0.1.132
     module load intel-cc/17.0.1.132

--- a/build/environs.nci
+++ b/build/environs.nci
@@ -1,7 +1,7 @@
 source /etc/profile.d/nf_csh_modules
-if ( -f ../../../modules.nci ) then
+if ( -f ../../modules.nci ) then
     echo "Loading common modules via modules.nci"
-    source ../../../modules.nci
+    source ../../modules.nci
 else
     echo "WARNING: modules.nci not found. Module versions might differ between model components."
     module purge


### PR DESCRIPTION
As discussed here: 
https://arccss.slack.com/archives/C6PP0GU9Y/p1516678999000106
but `modules.nci` is now called `environs.access-om2.nci`
and specifies `openmpi/1.10.2`, not `openmpi/3.0.0`

There are related pull requests for the other model components.